### PR TITLE
启动clamav服务前先下载病毒库

### DIFF
--- a/docs/user_manual/toolbox/clam.md
+++ b/docs/user_manual/toolbox/clam.md
@@ -54,6 +54,7 @@
         **5、启动 ClamAV 服务**
         
         ```bash
+        freshclam
         systemctl start clamd@scan.service
         systemctl start clamav-freshclam.service
         ```
@@ -83,6 +84,7 @@
         **2、启动 ClamAV 服务**
         
         ```bash
+        freshclam
         sudo systemctl start clamav-daemon
         sudo systemctl start clamav-freshclam.service
         ```


### PR DESCRIPTION
启动clamav服务前先下载病毒库,否则第一次启动clamav时会报病毒库不存在